### PR TITLE
feat: remove notifications older than 1 year periodically

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@sentry/tracing": "^7.46.0",
     "axios": "^1.1.2",
     "bcrypt": "^5.1.0",
+    "cron": "^3.1.7",
     "dotenv": "^16.0.1",
     "expo-server-sdk": "^3.10.0",
     "express": "^4.18.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ dependencies:
   bcrypt:
     specifier: ^5.1.0
     version: 5.1.0
+  cron:
+    specifier: ^3.1.7
+    version: 3.1.7
   dotenv:
     specifier: ^16.0.1
     version: 16.0.1
@@ -815,6 +818,10 @@ packages:
     resolution: {integrity: sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==}
     dev: false
 
+  /@types/luxon@3.4.2:
+    resolution: {integrity: sha512-TifLZlFudklWlMBfhubvgqTXRzLDI5pCbGa4P8a3wPyUQSW+1xQ5eDsreP9DWHX3tjq1ke96uYG/nwundroWcA==}
+    dev: false
+
   /@types/mime@1.3.2:
     resolution: {integrity: sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==}
 
@@ -1447,6 +1454,13 @@ packages:
   /create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
     dev: true
+
+  /cron@3.1.7:
+    resolution: {integrity: sha512-tlBg7ARsAMQLzgwqVxy8AZl/qlTc5nibqYwtNGoCrd+cV+ugI+tvZC1oT/8dFH8W455YrywGykx/KMmAqOr7Jw==}
+    dependencies:
+      '@types/luxon': 3.4.2
+      luxon: 3.4.4
+    dev: false
 
   /cross-env@7.0.3:
     resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
@@ -2355,6 +2369,11 @@ packages:
 
   /lru_map@0.3.3:
     resolution: {integrity: sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ==}
+    dev: false
+
+  /luxon@3.4.4:
+    resolution: {integrity: sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==}
+    engines: {node: '>=12'}
     dev: false
 
   /make-dir@3.1.0:

--- a/src/crons.ts
+++ b/src/crons.ts
@@ -1,0 +1,40 @@
+import { CronJob } from "cron";
+import prisma from "../prisma/client";
+import * as Sentry from "@sentry/node";
+
+const EVERY_DAY_AT_MIDNIGHT_CRON = "0 0 * * *";
+
+export const oldNotificationDeletionCron = CronJob.from({
+  cronTime: EVERY_DAY_AT_MIDNIGHT_CRON,
+  onTick: async () => {
+    const oneYearAgo = new Date(
+      new Date().setFullYear(new Date().getFullYear() - 1),
+    );
+    console.log(
+      "Running cron job to delete notifications older than: " + oneYearAgo,
+    );
+    try {
+      const res = await prisma.notification.deleteMany({
+        where: {
+          recived: {
+            lte: oneYearAgo,
+          },
+        },
+      });
+      console.log("Deleted " + res.count + " notifications");
+    } catch (error) {
+      console.error("Error deleting notifications", error);
+      Sentry.withScope((scope) => {
+        scope.setTag("cron", true);
+        scope.setContext("Cron", {
+          name: "oldNotificationDeletionCron",
+          schedule: EVERY_DAY_AT_MIDNIGHT_CRON,
+        });
+        scope.setExtra("date", oneYearAgo);
+        Sentry.captureException(error);
+      });
+    }
+  },
+  // Prevent the cron from starting automatically
+  start: false,
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import * as Tracing from "@sentry/tracing";
 import * as Profiling from "@sentry/profiling-node";
 import { RewriteFrames } from "@sentry/integrations";
 import prisma from "../prisma/client";
+import { oldNotificationDeletionCron } from "./crons";
 
 const app = express();
 const port = process.env.PORT ?? 8080;
@@ -106,6 +107,7 @@ app.use(handleError);
 if (process.env.NODE_ENV !== "test") {
   app.listen(port, () => {
     console.log(`Server is running at http://localhost:${port}`);
+    oldNotificationDeletionCron.start();
   });
 }
 


### PR DESCRIPTION
Added a cron job that removes notifications older than a year, we assume that they would not be consulted ever again. and also we need to save some space in the database